### PR TITLE
Small build fixes:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
-build:
+build: clean
 	GITHUB_TOKEN=$(GITHUB_TOKEN) ./build-release.sh
+
+clean:
+	rm -rf release release.tar.gz

--- a/build-release.sh
+++ b/build-release.sh
@@ -13,4 +13,4 @@ mkdir release/binaries
 # build overlay-runner
 GITHUB_TOKEN=$GITHUB_TOKEN ./ci-runners-build.sh
 cd release
-tar -zcpf ../release.tar.gz --xform s:'./':: .
+tar -zvcpf ../release.tar.gz $(find . -type f | sed -e 's!./!!')


### PR DESCRIPTION
* clean removes release data; clean before building
* tar --xform is a GNU tar thing (doesn't work on OS X). Replace with
more POSIX-friendly `find . -type f | sed -e 's!./!!'`.
* Output filenames on tar so it's not 10 minutes of silence.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>